### PR TITLE
Add API Items resource

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 3.8'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     execjs (2.7.0)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -201,6 +206,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)
+  factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,0 +1,51 @@
+# Api module
+module Api
+  # Items controller class
+  class ItemsController < ApplicationController
+    def index
+      @items = Item.all
+      render json: @items, status: :ok
+    end
+
+    def create
+      @item = Item.new(post_params)
+      respond_to do |format|
+        if @item.save
+          format.json { render json: @item, status: :created }
+        else
+          format.json { render json: @item.errors, status: :bad_request }
+        end
+      end
+    rescue ActionController::ParameterMissing => e
+      render json: { error: e.to_s }, status: :unprocessable_entity
+    end
+
+    def update
+      @item = Item.find(params[:id])
+      @item.update(put_params)
+      render json: @item, status: :ok
+    rescue ActiveRecord::RecordNotFound => e
+      render json: { error: e.to_s }, status: :not_found
+    rescue ActionController::ParameterMissing => e
+      render json: { error: e.to_s }, status: :unprocessable_entity
+    end
+
+    def destroy
+      @item = Item.find(params[:id])
+      @item.destroy
+      # TODO: research how to avoid repeating this
+    rescue ActiveRecord::RecordNotFound
+      head :no_content
+    end
+
+    private
+
+    def post_params
+      params.require(:item).permit(:text, :checked)
+    end
+
+    def put_params
+      params.require(:item).permit(:checked)
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
+# Application controller
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    resources :items, except: [:new, :edit]
+  end
 end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Api::ItemsController, type: :request do
         delete api_item_path(item.id)
       end
 
-      it "destory exisitng item and respond with with 'no_content'" do
+      it "destroy existing item and respond with with 'no_content'" do
         expect(response).to have_http_status(:no_content)
       end
     end
@@ -49,7 +49,7 @@ RSpec.describe Api::ItemsController, type: :request do
         delete api_item_path(item.id)
       end
 
-      it "destroy non existing item and respond with 'no_content'" do
+      it "responds with 'no_content'" do
         expect(response).to have_http_status(:no_content)
       end
     end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe Api::ItemsController, type: :request do
+  describe 'POST #create' do
+    context 'when item is valid' do
+      let(:item) { { text: 'test', checked: false } }
+      let(:params) { { item: item, format: :json } }
+      before do
+        post api_items_path, params: params
+      end
+
+      it 'returns http response success' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'returns a json with the item text attribute' do
+        expect(JSON.parse(response.body)['text']).to eq(item[:text])
+      end
+    end
+
+    context 'when params are missing' do
+      let(:item) { {} }
+      let(:params) { { item: item, format: :json } }
+      before do
+        post api_items_path, params: params
+      end
+      it 'returns http code 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'when item exists' do
+      let(:item) { FactoryBot.create :item }
+      before do
+        delete api_item_path(item.id)
+      end
+
+      it "destory exisitng item and respond with with 'no_content'" do
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context 'when item does not exist' do
+      let(:item) { FactoryBot.create :item }
+      before do
+        item.destroy
+        delete api_item_path(item.id)
+      end
+
+      it "destroy non existing item and respond with 'no_content'" do
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'when all fields are valid' do
+      let(:item) { FactoryBot.create :item }
+      let(:params) { { item: { checked: true }, format: :json } }
+      before do
+        put api_item_path(item.id), params: params
+      end
+
+      it 'should respond with JSON of item' do
+        expect(JSON.parse(response.body)['checked']).to eq(true)
+      end
+
+      it 'should respond with SUCCESS status code 200' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when fields are missing' do
+      let(:item) { FactoryBot.create :item }
+      let(:params) { { item: {}, format: :json } }
+      before do
+        put api_item_path(item.id), params: params
+      end
+
+      it 'should respond with 422' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when can not find item' do
+      let(:item) { FactoryBot.create :item }
+      let(:params) { { item: { checked: true }, format: :json } }
+      before do
+        item.destroy
+        put api_item_path(item.id), params: params
+      end
+
+      it 'should respond with 404 status' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :item do
+    text { 'some text' }
+    checked { false }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
📖 Story
This pull request is for creating the Items controller. 
To create the tests for the controller I employed the use of FactoryBot gem to help create items. 
I created specs of type `request` to test the `Item` controller.
I created an API namespace to group all its resources (for the moment there is only one)

🦋Changes
- Add FactoryBot gem
- Add config for FactoryBot in rails_helper
- Add file creating items factory
- Create tests for POST, DELETE and UPDATE methods in the API Item controller
- Add routes to items resource in the API namespace, except new and edit
- Add code to protect from forgery with null session, so the API request (revisit)
- Create items controller with POST, DELETE and UPDATE methods

🗒 Notes
Need to run `bundle install` to install FactoryBot gem.

❗️ TODO
- Group error handling in API application controller to avoid repeating similar code on each method in the Items controller

