### PR TITLE
Add tests for views

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem 'jquery-rails'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'capybara'
   gem 'rspec-rails', '~> 3.8'
   gem 'factory_bot_rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
     bindex (0.8.1)
@@ -49,6 +51,14 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.1)
+    capybara (3.29.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -101,6 +111,7 @@ GEM
     parallel (1.17.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    public_suffix (4.0.1)
     puma (3.12.1)
     rack (2.0.7)
     rack-test (1.1.0)
@@ -134,6 +145,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    regexp_parser (1.6.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.5)
@@ -202,6 +214,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -209,6 +223,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
   jbuilder (~> 2.5)

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe HomeController, type: :controller do
+  describe 'GET #index' do
+    let(:action) { get :index }
+    before do
+      get :index
+    end
+
+    it 'returns http success' do
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
+require 'capybara/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/views/api/items/_item_spec.rb
+++ b/spec/views/api/items/_item_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe 'api/items/_item', type: :view do
+  let(:item) { FactoryBot.create :item }
+
+  it 'renders item with text' do
+    render partial: 'api/items/item', locals: { item: item }
+    expect(rendered).to have_content(item.text)
+  end
+
+  it 'renders item with link to delete it' do
+    render partial: 'api/items/item', locals: { item: item }
+    expect(rendered).to have_link('Delete', exact: true, href: api_item_path(item))
+  end
+
+  it 'renders item with checkbox to check it - unchecked by default' do
+    render partial: 'api/items/item', locals: { item: item }
+    expect(rendered).to have_field('item_checked', checked: false)
+  end
+
+  it 'renders item with checkbox to check it - checked if item.checked?' do
+    item = FactoryBot.create :item, checked: true
+    render partial: 'api/items/item', locals: { item: item }
+    expect(rendered).to have_field('item_checked', checked: true)
+  end
+end

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe 'home/index.html.erb', type: :view do
+  it 'has basic layout: header' do
+    render
+    expect(rendered).to have_content('FORGET ME NOT')
+  end
+
+  it 'has basic layout: form - text field, and submit button' do
+    render
+    expect(rendered).to have_field('text')
+    expect(rendered).to have_button('Add')
+  end
+end


### PR DESCRIPTION
📖 Story
This pull request brings in tests for the views. First time doing so myself 😄 

🦋Changes
- Add the capybara gem so we can use some of the handy helpers like `have_content` or `have_link`. Require capybara in `rails_helper.rb`
- Create tests for the Home Index template: Check the header exist, and the input box and the button to submit a new item into the list
- Create tests to test the partial template for each item on the list (plus new items rendered as JS on the AJAX requests): Check presence of the right text, a link to delete (with the right URL), and a checkbox that will be properly toggled matching the value of `item.checked?`
- Create a very basic test for the Home controller

🗒 Notes
- run `bundle install` to ensure you bring in new dependencies (e.g. capybara)
- TODO: feature tests with Capybara, as soon as I figure out why Chromium is not properly submitting my forms with `format:js`